### PR TITLE
Redone code coverage reports

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,3 +34,5 @@ jobs:
         gem install bundler
         bundle install --jobs 4 --retry 3
         bundle exec rspec
+    - name: Check `simplecov` result coverage
+      run: cat coverage/.last_run.json | jq '.result.covered_percent' | grep -q '100'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### New Features
 
 * Use `markdownlint` for checking md files in CI
+* Add check for 100% test coverage in CI
 
 ### Changes
 
 * Use GitHub Actions instead of TravisCI
+* Remove usage of `codecov`

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem 'onlyoffice_file_helper'
 gem 'rake', '>= 12'
 
 group :test do
-  gem 'codecov', require: false
   gem 'rspec'
+  gem 'simplecov', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ GEM
   specs:
     ast (2.4.1)
     childprocess (4.0.0)
-    codecov (0.2.13)
-      simplecov (~> 0.18.0)
     diff-lcs (1.4.4)
     docile (1.3.2)
     iniparse (1.5.0)
@@ -61,13 +59,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  codecov
   nokogiri
   onlyoffice_file_helper
   overcommit
   rake (>= 12)
   rspec
   rubocop
+  simplecov
 
 BUNDLED WITH
    2.1.4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,4 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
 require_relative '../lib/documentbuilder_script_generator'


### PR DESCRIPTION
* Add check for 100% test coverage in CI
* Remove usage of `codecov`